### PR TITLE
add gen event info product to ntuple

### DIFF
--- a/Ntuplizer/config.py
+++ b/Ntuplizer/config.py
@@ -213,6 +213,7 @@ process.ntuplizer = cms.EDAnalyzer("Ntuplizer",
     rho = cms.InputTag("fixedGridRhoFastjetAll"),
     genparticles = cms.InputTag("prunedGenParticles"),
     PUInfo = cms.InputTag("addPileupInfo"),
+    genEventInfo = cms.InputTag("generator"),
     HLT = cms.InputTag("TriggerResults","","HLT"),
 )
 

--- a/Ntuplizer/interface/NtupleBranches.h
+++ b/Ntuplizer/interface/NtupleBranches.h
@@ -52,6 +52,8 @@ public:
     float                               lheV_pt              ;
     float                               lheHT                ;
     float                               lheNj                ;
+    float                               genWeight            ;
+    float                               qScale               ;
     std::vector<float>  	        genParticle_pt	     ;
     std::vector<float>  	        genParticle_px	     ;
     std::vector<float>  	        genParticle_py	     ;

--- a/Ntuplizer/interface/Ntuplizer.h
+++ b/Ntuplizer/interface/Ntuplizer.h
@@ -45,6 +45,7 @@ private:
   edm::EDGetTokenT<reco::VertexCollection>  				vtxToken_   		;
   edm::EDGetTokenT<double>  		    					rhoToken_   		;
   edm::EDGetTokenT< std::vector<PileupSummaryInfo> > 		puinfoToken_		;
+  edm::EDGetTokenT< GenEventInfoProduct > 		geneventToken_		;
   
   edm::EDGetTokenT<reco::GenParticleCollection> 			genparticleToken_	;
   

--- a/Ntuplizer/plugins/NtupleBranches.cc
+++ b/Ntuplizer/plugins/NtupleBranches.cc
@@ -34,6 +34,8 @@ void NtupleBranches::branch( void ){
   tree_->Branch( "lheV_pt"	             , &lheV_pt                ); 
   tree_->Branch( "lheHT"	             , &lheHT                  ); 
   tree_->Branch( "lheNj"	             , &lheNj                  ); 
+  tree_->Branch( "genWeight"	             , &genWeight              ); 
+  tree_->Branch( "qScale"	             , &qScale                 ); 
   
   /*-------------------------leptons----------------------------*/
   tree_->Branch( "nlep"  		     , &nlep		       );
@@ -236,6 +238,8 @@ void NtupleBranches::reset( void ){
   lheV_pt     = 0;
   lheHT       = 0;
   lheNj       = 0;
+  genWeight   = 0;
+  qScale      = 0;
   nlep        = 0;
   njetsAK4    = 0;
   njetsAK8    = 0;  

--- a/Ntuplizer/plugins/Ntuplizer.cc
+++ b/Ntuplizer/plugins/Ntuplizer.cc
@@ -5,6 +5,7 @@
 #include "../interface/ElectronsNtuplizer.h"
 #include "../interface/METsNtuplizer.h"
 #include "../interface/PileUpNtuplizer.h"
+#include "../interface/GenEventNtuplizer.h"
 #include "../interface/GenParticlesNtuplizer.h"
 #include "../interface/TriggersNtuplizer.h"
 #include "../interface/VerticesNtuplizer.h"
@@ -16,6 +17,7 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
 	vtxToken_		(consumes<reco::VertexCollection>				(iConfig.getParameter<edm::InputTag>("vertices"))),
 	rhoToken_		(consumes<double>						(iConfig.getParameter<edm::InputTag>("rho"))),
 	puinfoToken_    	(consumes<std::vector<PileupSummaryInfo> >		        (iConfig.getParameter<edm::InputTag>("PUInfo"))),
+	geneventToken_    	(consumes<GenEventInfoProduct>				        (iConfig.getParameter<edm::InputTag>("genEventInfo"))),
 	
 	genparticleToken_ 	(consumes<reco::GenParticleCollection>			        (iConfig.getParameter<edm::InputTag>("genparticles"))),
 	
@@ -80,6 +82,10 @@ Ntuplizer::Ntuplizer(const edm::ParameterSet& iConfig):
      std::vector<edm::EDGetTokenT< std::vector<PileupSummaryInfo> > > puTokens;
      puTokens.push_back( puinfoToken_ );
      nTuplizers_["PU"] = new PileUpNtuplizer( puTokens, nBranches_ );
+
+     std::vector<edm::EDGetTokenT< GenEventInfoProduct > > geneTokens;
+     geneTokens.push_back( geneventToken_ );
+     nTuplizers_["genEvent"] = new GenEventNtuplizer( geneTokens, nBranches_ );
   }
 }
 


### PR DESCRIPTION
the generator weight information is useful to properly weight "flat" QCD samples.